### PR TITLE
fix: handle versions without v prefix

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -46,6 +46,9 @@ function install_rabbitmq {
 		_semver=${_version#v}
 	elif [[ ${version} =~ "v".* ]]; then
 		_semver=${version#v}
+  elif [[ ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)?$ ]]; then
+    version="v${version}"
+    _semver=${version#v}
 	else
 		echo "ERROR: unsupported version format ${version}"
 		exit 1

--- a/bin/install
+++ b/bin/install
@@ -60,11 +60,7 @@ function install_rabbitmq {
 	# If rabbitmq $version >= 3.6.0
 	if [[ ${_semver//.} -ge '360' ]]; then
 		url=https://github.com/rabbitmq/rabbitmq-server/releases/download/$version/$os_prefix-$_semver.tar.xz
-		status=$(curl --write-out %{http_code} -L $url --output $tmp_download_dir/rabbitmq.tar.xz)
-		if [ $status -ne 200 ]; then
-			echo "ERROR: version ${version} is not available for download."
-			exit 1
-		fi
+		curl --write-out %{http_code} -fL $url --output $tmp_download_dir/rabbitmq.tar.xz
 		if command -v gpg; then
 			verify_package "${url}" "${tmp_download_dir}" "xz"
 		else

--- a/bin/install
+++ b/bin/install
@@ -46,9 +46,9 @@ function install_rabbitmq {
 		_semver=${_version#v}
 	elif [[ ${version} =~ "v".* ]]; then
 		_semver=${version#v}
-  elif [[ ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)?$ ]]; then
-    version="v${version}"
-    _semver=${version#v}
+	elif [[ ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)?$ ]]; then
+		version="v${version}"
+		_semver=${version#v}
 	else
 		echo "ERROR: unsupported version format ${version}"
 		exit 1
@@ -60,7 +60,11 @@ function install_rabbitmq {
 	# If rabbitmq $version >= 3.6.0
 	if [[ ${_semver//.} -ge '360' ]]; then
 		url=https://github.com/rabbitmq/rabbitmq-server/releases/download/$version/$os_prefix-$_semver.tar.xz
-		curl -L $url --output $tmp_download_dir/rabbitmq.tar.xz
+		status=$(curl --write-out %{http_code} -L $url --output $tmp_download_dir/rabbitmq.tar.xz)
+		if [ $status -ne 200 ]; then
+			echo "ERROR: version ${version} is not available for download."
+			exit 1
+		fi
 		if command -v gpg; then
 			verify_package "${url}" "${tmp_download_dir}" "xz"
 		else


### PR DESCRIPTION
As mentioned in https://github.com/jdx/mise/issues/1776, versions without `v` prefix do currently not work.