### PR TITLE
feat: add GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+on:
+  pull_request:
+    branches: ["master"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+          experimental: true
+      - run: mise run lint 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,9 @@
+[tools]
+shfmt = "latest"
+shellcheck = "latest"
+
+[tasks.lint]
+run = [
+  "shellcheck ./bin/*",
+  "shfmt -i 2 -w -s ./bin/*"
+]


### PR DESCRIPTION
Not sure if this works. Tried to verify the workflow locally with `act` but got the following error.

```
  ✖ gh act pull_request --container-architecture linux/amd64
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock'
[test/unit] 🚀  Start image=node:16-buster-slim
INFO[0000] Parallel tasks (0) below minimum, setting to 1
[test/unit]   🐳  docker pull image=node:16-buster-slim platform=linux/amd64 username= forcePull=true
INFO[0001] Parallel tasks (0) below minimum, setting to 1
[test/unit]   🐳  docker create image=node:16-buster-slim platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[test/unit]   🐳  docker run image=node:16-buster-slim platform=linux/amd64 entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[test/unit]   ☁  git clone 'https://github.com/jdx/mise-action' # ref=v2
[test/unit] ⭐ Run Main actions/checkout@v3
[test/unit]   🐳  docker cp src=/Users/roele/Dev/github.com/roele/asdf-rabbitmq/. dst=/Users/roele/Dev/github.com/roele/asdf-rabbitmq
[test/unit]   ✅  Success - Main actions/checkout@v3
[test/unit] ⭐ Run Main jdx/mise-action@v2
[test/unit]   🐳  docker cp src=/Users/roele/.cache/act/jdx-mise-action@v2/ dst=/var/run/act/actions/jdx-mise-action@v2/
[test/unit]   🐳  docker exec cmd=[node /var/run/act/actions/jdx-mise-action@v2/dist/index.js] user= workdir=
[test/unit]   ❓  ::group::Restoring mise cache
[test/unit]   💬  ::debug::followSymbolicLinks 'true'
[test/unit]   💬  ::debug::followSymbolicLinks 'true'
[test/unit]   💬  ::debug::implicitDescendants 'true'
[test/unit]   💬  ::debug::matchDirectories 'true'
[test/unit]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[test/unit]   💬  ::debug::Search path '/Users/roele/Dev/github.com/roele/asdf-rabbitmq'
[test/unit]   💬  ::debug::No matches found for glob
[test/unit]   💬  ::debug::Resolved Keys:
[test/unit]   💬  ::debug::["mise-v0-linux-x64-"]
[test/unit]   💬  ::debug::Checking zstd --quiet --version
[test/unit]   💬  ::debug::Unable to locate executable file: zstd. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.
[test/unit]   💬  ::debug::
[test/unit]   💬  ::debug::zstd version: null
[test/unit]   💬  ::debug::Resource Url: http://10.5.0.2:49994/_apis/artifactcache/cache?keys=mise-v0-linux-x64-&version=1e1fdf66639ec8cb14c44fd5cdfb636bc9756185c87d7021073d7ee69f8762cc
```